### PR TITLE
Support psalm and phpstan generics

### DIFF
--- a/src/AbstractServiceFactory.php
+++ b/src/AbstractServiceFactory.php
@@ -5,15 +5,24 @@ namespace Aeviiq\Factory;
 use Aeviiq\Factory\Exception\LogicException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * @psalm-template T of object
+ * @phpstan-template T of object
+ *
+ * @psalm-implements FactoryInterface<T>
+ * @phpstan-implements FactoryInterface<T>
+ */
 abstract class AbstractServiceFactory implements FactoryInterface
 {
     /**
-     * @var ContainerInterface
+     * @var ContainerInterface|null
      */
     private $container;
 
     /**
-     * @var string[][]
+     * @psalm-var array<class-string<T>, array<int, string>>
+     * @phpstan-var array<class-string<T>, array<int, string>>
+     * @var array<string, array<int, string>>
      */
     private $serviceIds = [];
 
@@ -32,13 +41,6 @@ abstract class AbstractServiceFactory implements FactoryInterface
         return $target;
     }
 
-    /**
-     * @template T
-     * @param class-string<T> $fqn
-     *
-     * @return T
-     * @throws LogicException
-     */
     final public function getByFqn(string $fqn): object
     {
         return $this->getOneBy(static function (object $service) use ($fqn): bool {
@@ -46,15 +48,21 @@ abstract class AbstractServiceFactory implements FactoryInterface
         });
     }
 
-    final public function setContainer(ContainerInterface $container = null): void
+    final public function setContainer(?ContainerInterface $container = null): void
     {
         $this->container = $container;
     }
 
+    /**
+     * @psalm-return class-string<T>
+     * @phpstan-return class-string<T>
+     */
     abstract protected function getTargetInterface(): string;
 
     /**
-     * @return object[] The services that are registered with this factory.
+     * @psalm-return array<int, T>
+     * @phpstan-return array<int, T>
+     * @return array<int, object> The services that are registered with this factory.
      */
     protected function getServices(): array
     {
@@ -64,6 +72,9 @@ abstract class AbstractServiceFactory implements FactoryInterface
     }
 
     /**
+     * @psalm-return T
+     * @phpstan-return T
+     *
      * @throws LogicException When no service was found.
      */
     protected function getOneBy(callable $criteria): object
@@ -77,6 +88,9 @@ abstract class AbstractServiceFactory implements FactoryInterface
     }
 
     /**
+     * @psalm-return T|null
+     * @phpstan-return T|null
+     *
      * @throws LogicException When multiple services were found.
      */
     protected function getOneOrNullBy(callable $criteria): ?object

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -2,16 +2,32 @@
 
 namespace Aeviiq\Factory;
 
+use Aeviiq\Factory\Exception\LogicException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
+/**
+ * @psalm-template T of object
+ * @phpstan-template T of object
+ */
 interface FactoryInterface extends ContainerAwareInterface
 {
     public function register(string $serviceId): void;
 
     /**
+     * @psalm-return class-string<T>
+     * @phpstan-return class-string<T>
      * @return string FQN of the target class
      */
     public function getTarget(): string;
 
+    /**
+     * @psalm-param class-string<T> $fqn
+     * @phpstan-param class-string<T> $fqn
+     *
+     * @psalm-return T
+     * @phpstan-return T
+     *
+     * @throws LogicException
+     */
     public function getByFqn(string $fqn): object;
 }


### PR DESCRIPTION
This allows both psalm and phpstan to infer the return types and param types for all functions.

It enables the following:
```php
/**
 * @psalm-extends AbstractServiceFactory<Bar>
 * @phpstan-extends AbstractServiceFactory<Bar>
 */
class Foo extends AbstractServiceFactory {
    protected function getTargetInterface(): string {
        return Bar::class;
    }
}

//

$baz = $foo->getOneBy(function(Bar $bar){});
// phpstan and psalm know that $baz is an instance of Bar, not just any object.
```